### PR TITLE
Rework simple Toolbarcomponent with the composition api

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@fortawesome/fontawesome-free": "^5.12.1",
     "@jimber/pkid": "^1.0.4",
     "@jimber/stellar-crypto": "^0.13.1",
+    "@vue/composition-api": "^0.5.0",
     "axios": "^0.19.2",
     "bip39": "latest",
     "clipboard-copy": "^3.1.0",

--- a/src/components/Toolbar.vue
+++ b/src/components/Toolbar.vue
@@ -1,5 +1,5 @@
-<template
-    ><section class="toolbar">
+<template>
+    <section class="toolbar">
         <v-app-bar color="primary" dark>
             <v-btn v-if="showBack" text small fab dark :to="{ name: 'home' }">
                 <v-icon flatclass="white--text" icon>fas fa-wallet</v-icon>
@@ -13,7 +13,6 @@
             </v-toolbar-title>
 
             <v-spacer></v-spacer>
-
 
             <v-btn
                 x-small
@@ -42,21 +41,19 @@
     </section>
 </template>
 <script>
-    import { mapGetters, mapMutations } from 'vuex';
+    import { computed } from '@vue/composition-api';
 
     export default {
-        components: {},
-        name: 'Toolbar',
-        props: [],
-        data() {
-            return {
-                isScrolling: false,
-            };
-        },
-        computed: {
-            ...mapGetters(['syncing', 'accounts', 'devClicks']),
-            showBack() {
-                const { name } = this.$route;
+        setup(_, context) {
+            debugger;
+            const {root} = context;
+
+            const addDevClick = () => root.$store.commit('addDevClick');
+
+            const restartWallet = () => location.replace('/init');
+
+            const showBack = computed(() => {
+                const { name } = root.$route;
                 return (
                     name !== 'home' &&
                     name !== 'login' &&
@@ -64,18 +61,14 @@
                     name !== 'error screen' &&
                     name !== 'sms'
                 );
-            },
-        },
-        methods: {
-            ...mapMutations(['addDevClick']),
-            restartWallet() {
-                location.replace('/init');
-            },
+            });
+
+            return { addDevClick, restartWallet, showBack};
         },
     };
 </script>
 <style scoped lang="scss">
-    .toolbar{
+    .toolbar {
         position: sticky;
         top: 0;
         z-index: 99;

--- a/src/main.js
+++ b/src/main.js
@@ -8,6 +8,7 @@ import filters from './utils/filters';
 import '@fortawesome/fontawesome-free/css/all.css';
 import global from './components/global';
 import clipboardHack from './utils/clipboardhack';
+import VueCompositionApi from '@vue/composition-api';
 
 import config from '../public/config';
 
@@ -39,6 +40,7 @@ async function startVueApp() {
 
     await sodium.ready;
 
+    Vue.use(VueCompositionApi);
     Vue.use(filters);
     Vue.use(global);
     initializeFlutterInappwebviewPolyfill();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1572,6 +1572,13 @@
     source-map "~0.6.1"
     vue-template-es2015-compiler "^1.9.0"
 
+"@vue/composition-api@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@vue/composition-api/-/composition-api-0.5.0.tgz#2dbaa02a5d1f5d0d407d53d5529fe444aa8362f3"
+  integrity sha512-9QDFWq7q839G1CTTaxeruPOTrrVOPSaVipJ2TxxK9QAruePNTHOGbOOFRpc8WLl4YPsu1/c29yBhMVmrXz8BZw==
+  dependencies:
+    tslib "^1.9.3"
+
 "@vue/eslint-config-prettier@^5.0.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@vue/eslint-config-prettier/-/eslint-config-prettier-5.1.0.tgz#837241a26ed396976cb8dabd77939303245523cf"
@@ -10588,6 +10595,11 @@ tslib@^1, tslib@^1.10.0, tslib@^1.9.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
+
+tslib@^1.9.3:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
+  integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
 
 tty-browserify@0.0.0:
   version "0.0.0"


### PR DESCRIPTION
How:
* by introducing composition api by vue
* removing all default component structure (eg. mounted, computed,
methods)

Why:
* this will be the new norm when vue 3 comes around
* mostly for research
* refactoring toolbar, had some dead code